### PR TITLE
Add links lookup

### DIFF
--- a/src/main/_plugins/links.rb
+++ b/src/main/_plugins/links.rb
@@ -41,14 +41,17 @@ module Reading
           end
           
           collections = {}
-          collections=collections.merge(get_col(site,"docs",entries))
-          collections=collections.merge(get_col(site,"tutorials",entries))      
-          # puts collections
+          site.config["collections"].each do |collection|
+            if collection[0] != "posts"
+              collections=collections.merge(get_col(site,collection[0],entries))
+            end
+          end     
+          puts collections
           site.config["links"] = collections
       rescue 
           red = "\033[0;31m"
           puts red + "Jekyll> There is an error in the ruby plugin file _plugins/links.rb." 
-          puts red + "Jekyll> Check data files 'docs.yml' and 'tutorials.yml' under _data/ folder are formatted correctly."
+          puts red + "Jekyll> Check collection files such ass 'docs.yml' and 'tutorials.yml' under _data/ folder are formatted correctly."
           puts ""
           raise
       end

--- a/src/main/_plugins/links.rb
+++ b/src/main/_plugins/links.rb
@@ -3,11 +3,7 @@ module Reading
     def generate(site)
       begin
           docs = site.docs_to_write
-          
-          
-          
           entries = {}
-          
           site.collections["docs"].filtered_entries.each do |entry|
             page = ""
             site.config["defaults"].each do |default|
@@ -25,7 +21,6 @@ module Reading
                     end
                 end
             end
-              
             depth = page.split('/').size - 1
             base = ''
             if depth <= 1
@@ -39,7 +34,6 @@ module Reading
             end
             entries[entry]=base+page 
           end
-          
           collections = {}
           site.config["collections"].each do |collection|
             if collection[0] != "posts"

--- a/src/main/_plugins/links.rb
+++ b/src/main/_plugins/links.rb
@@ -1,0 +1,80 @@
+module Reading
+  class Generator < Jekyll::Generator
+    def generate(site)
+      begin
+          docs = site.docs_to_write
+          
+          
+          
+          entries = {}
+          
+          site.collections["docs"].filtered_entries.each do |entry|
+            page = ""
+            site.config["defaults"].each do |default|
+                scope = default["scope"]
+                path = scope["path"]
+                #puts path
+                full_path = "_docs/" + entry
+                #puts entry
+                if full_path.include? path
+                    value = default["values"]
+                    categories = value["categories"]
+                    
+                    categories.each do |category|
+                        page=page+"/"+category
+                    end
+                end
+            end
+              
+            depth = page.split('/').size - 1
+            base = ''
+            if depth <= 1
+                base = '..'
+            elsif depth == 2
+                base = '../..'
+            elsif depth == 3
+                base = '../../..'
+            elsif depth == 4
+                base = '../../../..'      
+            end
+            entries[entry]=base+page 
+          end
+          
+          collections = {}
+          collections=collections.merge(get_col(site,"docs",entries))
+          collections=collections.merge(get_col(site,"tutorials",entries))      
+          # puts collections
+          site.config["links"] = collections
+      rescue 
+          red = "\033[0;31m"
+          puts red + "Jekyll> There is an error in the ruby plugin file _plugins/links.rb." 
+          puts red + "Jekyll> Check data files 'docs.yml' and 'tutorials.yml' under _data/ folder are formatted correctly."
+          puts ""
+          raise
+      end
+    end
+    
+    def get_col(site,col_name, entries)
+        collections = {}
+        hash1 = site.data
+        hash1.each do |hash2|
+            hash3 = hash1[col_name]
+            hash3.each do |hash4|
+                
+                files = hash4[col_name]                
+                files.each do |file|
+                    parse = file.split('-')
+                    parse.shift
+                    parse = parse.join('-')
+                    entries.keys.any? {|k| 
+                        if k.include? file 
+                            collections[file]=entries[k]+"/"+parse+"/index.html"
+                        end
+                        }
+                end
+            end
+        end
+        return collections
+    end
+  end
+end

--- a/src/main/_plugins/links.rb
+++ b/src/main/_plugins/links.rb
@@ -9,13 +9,10 @@ module Reading
             site.config["defaults"].each do |default|
                 scope = default["scope"]
                 path = scope["path"]
-                #puts path
                 full_path = "_docs/" + entry
-                #puts entry
                 if full_path.include? path
                     value = default["values"]
                     categories = value["categories"]
-                    
                     categories.each do |category|
                         page=page+"/"+category
                     end


### PR DESCRIPTION
Adds ability to find relative path dynamically using the the markdown filename. This will help us as we will not be hardcoding paths such as "../../docs/getting-started/introduction/index.html" allowing us to restructure at a later date. Also when we use files from che-docs the links will automatically correct themselves for codenvy site. For example che-docs file "_docs/workspace-administration/ws-agents.md" has a permalink of "/docs/workspace/agents/" but under codenvy its "/docs/getting-started/agents/" . We would need to add _plugins/links.rb to che-docs as well once merged here.

This is an example of the new syntax to use in markdown file:
```
Refer to the [getting started page]({{ site.links["start-getting-started"] }}#install) for additional information.
```

Jekyll converts this to:
```
Refer to the [getting started page](../../docs/getting-started/getting-started/index.html#install) for additional information.
```
