### PR TITLE
Add setup-ssh page from che.

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -27,7 +27,8 @@ repository: https://github.com/codenvy/codenvy/
 timezone: America/Los_Angeles
 
 product_name: "CODENVY"
-product_mini_name:  "codenvy"
+product_mini_name:  "Codenvy"
+product_mini_cli: "codenvy"
 product_formal_name: "Codenvy"
 
 collections:

--- a/src/main/_data/docs.yml
+++ b/src/main/_data/docs.yml
@@ -38,6 +38,7 @@
   - ide-run # Che use-che-as-an-ide
   - ide-debug # Che use-che-as-an-ide
   - ide-sync # Che use-che-as-an-ide
+  - ide-ssh # Che use-che-as-an-ide
   - user-sharing-permissions
   - user-using-desktop-ides 
 - title: Admin Guide


### PR DESCRIPTION
Adds updated setup-ssh page from che PR https://github.com/codenvy/che-docs/pull/55 . 

Also capitalized `product_mini_name` value to match that used in che and added `product_mini_cli`. Ran search `product_mini_name` for this repo which is not used currently so this change will produce better results when this variable is used in che repo.