### PR TITLE
Remove che sync page

### DIFF
--- a/src/main/_data/docs.yml
+++ b/src/main/_data/docs.yml
@@ -39,7 +39,6 @@
   - ide-debug # Che use-che-as-an-ide
   - ide-sync # Che use-che-as-an-ide
   - user-sharing-permissions
-  - user-using-desktop-ides 
 - title: Admin Guide
   docs:
   - admin-installation

--- a/src/main/_data/docs.yml
+++ b/src/main/_data/docs.yml
@@ -38,6 +38,7 @@
   - ide-run # Che use-che-as-an-ide
   - ide-debug # Che use-che-as-an-ide
   - ide-sync # Che use-che-as-an-ide
+  - ide-ssh # Che use-che-as-an-ide
   - user-sharing-permissions
 - title: Admin Guide
   docs:

--- a/src/main/_data/docs.yml
+++ b/src/main/_data/docs.yml
@@ -38,7 +38,6 @@
   - ide-run # Che use-che-as-an-ide
   - ide-debug # Che use-che-as-an-ide
   - ide-sync # Che use-che-as-an-ide
-  - ide-ssh # Che use-che-as-an-ide
   - user-sharing-permissions
   - user-using-desktop-ides 
 - title: Admin Guide


### PR DESCRIPTION
We have this page in codenvy docs:
https://codenvy.com/docs/user-guide/using-desktop-ides/index.html

So this PR removes this Che page from Codenvy docs:
https://codenvy.com/docs/user-guide/sync/index.html