### PR TITLE
Reorganized TOC

### DIFF
--- a/src/main/_data/docs.yml
+++ b/src/main/_data/docs.yml
@@ -13,9 +13,17 @@
 # from Codenvy S.A..
 #
 
-- title: Getting Started
+- title: Admin Guide
   docs:
   - getting-started
+  - admin-installation
+  - admin-configuration
+  - admin-ldap
+  - admin-managing
+  - admin-cli
+  - admin-runbook
+- title: Workspace Guide
+  docs:
   - ws-admin-intro # Che workspace-administration
   - ws-stacks # Che workspace-administration
   - ws-recipes # Che workspace-administration
@@ -39,14 +47,6 @@
   - ide-sync # Che use-che-as-an-ide
   - ide-ssh # Che use-che-as-an-ide
   - user-sharing-permissions
-- title: Admin Guide
-  docs:
-  - admin-installation
-  - admin-configuration
-  - admin-ldap
-  - admin-managing
-  - admin-cli
-  - admin-runbook
 - title: Integration Guide
   docs:
   - integration-workspace-automation

--- a/src/main/_docs/admin-guide/admin-managing.md
+++ b/src/main/_docs/admin-guide/admin-managing.md
@@ -1,6 +1,6 @@
 ---
 tag: [ "codenvy" ]
-title: Managing
+title: Management
 excerpt: ""
 layout: docs
 permalink: /:categories/managing/


### PR DESCRIPTION
- Moved Admin Guide to the top to mirror Che and because most people have to install first
- Separated workspace administration into its own section